### PR TITLE
Add setup-node with Node.js 22 for cspell 10 compatibility

### DIFF
--- a/.github/workflows/hugo-deploy.yml
+++ b/.github/workflows/hugo-deploy.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -31,6 +31,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo


### PR DESCRIPTION
## Summary

- Add SHA-pinned `actions/setup-node@v4` with `node-version: '22'` to both `hugo-deploy.yml` and `pr-validate.yml`
- Unblocks Dependabot PR #33 (cspell 8.x → 10.0.0) which requires Node.js >=22.18.0
- `ubuntu-latest` currently ships Node.js 20.x, which is too old for cspell 10

## Test plan

- [ ] PR validation passes with Node.js 22
- [ ] After merge: re-run cspell 10 Dependabot PR #33 and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)