### PR TITLE
fix: Widen article content width on wide screens

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -280,3 +280,22 @@ article li p {
   background: rgba(255, 255, 255, 0.3) !important;
 }
 
+/* Widen article content on single pages for better code block display */
+@media (min-width: 853px) {
+  article #single_header {
+    max-width: 90ch !important;
+  }
+
+  article section.prose > div {
+    max-width: 90ch !important;
+  }
+
+  article .article-content {
+    max-width: 90ch !important;
+  }
+
+  article > footer {
+    max-width: 90ch !important;
+  }
+}
+


### PR DESCRIPTION
## Summary

- Override Blowfish theme's `max-w-prose` (65ch) constraint on article pages to `90ch` for wider content on desktop screens
- Applied at the theme's `md` breakpoint (853px) so mobile layout is unchanged
- Targets article header, content wrapper, article body, and footer — scoped to `article` elements only so homepage and gallery pages are unaffected

## Test plan

- [ ] Blog post content is visibly wider on desktop (e.g. `/blog/hardening-image-mode-builds/`)
- [ ] Code blocks render at comfortable width without horizontal scrolling
- [ ] Mobile layout (< 853px) is unchanged
- [ ] Homepage layout is unaffected
- [ ] Photo gallery pages are unaffected
- [ ] Hugo build succeeds (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)