### PR TITLE
fix: Widen article content and update blog post title

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -280,3 +280,22 @@ article li p {
   background: rgba(255, 255, 255, 0.3) !important;
 }
 
+/* Widen article content on single pages for better code block display */
+@media (min-width: 853px) {
+  article #single_header {
+    max-width: 90ch !important;
+  }
+
+  article section.prose > div {
+    max-width: 90ch !important;
+  }
+
+  article .article-content {
+    max-width: 90ch !important;
+  }
+
+  article > footer {
+    max-width: 90ch !important;
+  }
+}
+

--- a/content/blog/hardening-image-mode-builds.md
+++ b/content/blog/hardening-image-mode-builds.md
@@ -1,5 +1,5 @@
 ---
-title: "Experiences using and hardening RHEL image mode"
+title: "Hardening RHEL image mode for mission critical environments"
 description: "How to enforce supply chain integrity on RHEL image mode (bootc) appliances using cosign signature verification, SELinux lockdown, and filesystem immutability, and where the ecosystem is headed with composefs and IMA."
 author: "Chris Butler"
 date: 2026-03-25


### PR DESCRIPTION
## Summary

- Override Blowfish theme's `max-w-prose` (65ch) constraint on article pages to `90ch` for wider content on desktop screens
- Applied at the theme's `md` breakpoint (853px) so mobile layout is unchanged
- Targets article header, content wrapper, article body, and footer — scoped to `article` elements only so homepage and gallery pages are unaffected
- Fix blog post frontmatter title to match the H1 heading: "Hardening RHEL image mode for mission critical environments"

## Test plan

- [ ] Blog post content is visibly wider on desktop (e.g. `/blog/hardening-image-mode-builds/`)
- [ ] Code blocks render at comfortable width without horizontal scrolling
- [ ] Mobile layout (< 853px) is unchanged
- [ ] Homepage layout is unaffected
- [ ] Photo gallery pages are unaffected
- [ ] Page title shows "Hardening RHEL image mode for mission critical environments"
- [ ] Hugo build succeeds (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)